### PR TITLE
Updated Flickr's provider class to the "OAuth_*" naming convention

### DIFF
--- a/oauth/libraries/providers/flickr.php
+++ b/oauth/libraries/providers/flickr.php
@@ -16,9 +16,7 @@
  * @since      3.0.7
  */
 
-namespace OAuth;
-
-class Provider_Flickr extends Provider {
+class OAuth_Provider_Flickr extends OAuth_Provider {
 
 	public $name = 'flickr';
 


### PR DESCRIPTION
Simple update to the flickr provider class
