### PR TITLE
Handle Facebook cancel dialog (issue #28)

### DIFF
--- a/controllers/social.php
+++ b/controllers/social.php
@@ -182,6 +182,12 @@ class Social extends Public_Controller
 			
 			case 'oauth2':
 				
+				//check to ensure the GET string has 'code'. If not, we're probably dealing with a 
+				// user-initated cancel (eg. Facebook cancel perms request)
+				if( !isset($_GET['code'])) {
+					redirect('/');
+				}
+				
 				// Grab the access token from the code
 				$token = $provider->access($_GET['code']);
 


### PR DESCRIPTION
Hi Phil, I encountered an issue in my application where users hit the CANCEL button on the Facebook permissions dialog (it's outlined in issue #28). This is a simple little fix for it. I put it in the place that seemed to make sense.

(This is my first ever pull request, so apologies in advance if I haven't done it all correctly)
