### PR TITLE
Trigger post_user_login when logged in via social module

### DIFF
--- a/controllers/social.php
+++ b/controllers/social.php
@@ -269,6 +269,9 @@ class Social extends Public_Controller
 			    show_error('Failed to log you in.');
 			}
 		
+			// trigger a post login event for third party devs
+			Events::trigger('post_user_login');
+			
 			$this->session->set_flashdata('success', lang('user_logged_in'));
 		    redirect('/');
 		}


### PR DESCRIPTION
Trigger the post_user_login when an user logged in via social module, will be useful for other modules to detect when an user is logged in.
