### PR TITLE
Fixes for PyroCMS 2.2.3

### DIFF
--- a/controllers/admin.php
+++ b/controllers/admin.php
@@ -45,7 +45,7 @@ class Admin extends Admin_Controller
 		// Look for all oauth and oauth2 strategies
 		foreach (array('oauth', 'oauth2') as $strategy)
 		{		
-			if (($libraries = glob($this->module_details['path'].'/'.$strategy.'/libraries/Provider/*.php')))
+			if (($libraries = glob($this->module_details['path'].'/'.$strategy.'/libraries/providers/*.php')))
 			{
 				// Build an array of what is available
 				foreach ($libraries as $provider)

--- a/events.php
+++ b/events.php
@@ -19,7 +19,7 @@ class Events_Social
         Events::register('post_user_register', array($this, 'save_authentication'));
 
 		// Post a blog to twitter and whatnot
-		Events::register('blog_article_published', array($this, 'post_status'));
+		Events::register('post_published', array($this, 'post_status'));
 
 		// User deleted clean up any authentications
 		Events::register('user_deleted',array($this,'remove_authentications'));


### PR DESCRIPTION
The blog post event’s name changed.
A typo on the path of OAuth’s providers.
